### PR TITLE
fix: open templates with explicit utf-8 encoding

### DIFF
--- a/anki_addon/notetypes.py
+++ b/anki_addon/notetypes.py
@@ -177,15 +177,15 @@ class NoteTypeManager:
     def __init__(self):
         # Read default templates' markups and style
         templates_dir = path.join(path.dirname(__file__), 'templates')
-        with open(path.join(templates_dir, 'style.css'), 'r') as file:
+        with open(path.join(templates_dir, 'style.css'), 'r', encoding='utf-8') as file:
             style = file.read()
-        with open(path.join(templates_dir, 'into_estonian_front.html'), 'r') as file:
+        with open(path.join(templates_dir, 'into_estonian_front.html'), 'r', encoding='utf-8') as file:
             markup_into_estonian_front = file.read()
-        with open(path.join(templates_dir, 'into_estonian_back.html'), 'r') as file:
+        with open(path.join(templates_dir, 'into_estonian_back.html'), 'r', encoding='utf-8') as file:
             markup_into_estonian_back = file.read()
-        with open(path.join(templates_dir, 'from_estonian_front.html'), 'r') as file:
+        with open(path.join(templates_dir, 'from_estonian_front.html'), 'r', encoding='utf-8') as file:
             markup_from_estonian_front = file.read()
-        with open(path.join(templates_dir, 'from_estonian_back.html'), 'r') as file:
+        with open(path.join(templates_dir, 'from_estonian_back.html'), 'r', encoding='utf-8') as file:
             markup_from_estonian_back = file.read()
 
         # Default card templates


### PR DESCRIPTION
Fixes the following crash on startup:
```
Anki 24.11 (87ccd24e)  (ao)
Python 3.9.18 Qt 6.6.2 PyQt 6.6.1
Platform: macOS-15.2-x86_64-i386-64bit

When loading anki-sonaveeb:
Traceback (most recent call last):
  File "aqt.addons", line 250, in loadAddons
  File "/Users/s10/Library/Application Support/Anki2/addons21/anki-sonaveeb/__init__.py", line 24, in <module>
    notetype_manager = NoteTypeManager()
  File "/Users/s10/Library/Application Support/Anki2/addons21/anki-sonaveeb/notetypes.py", line 185, in __init__
    markup_into_estonian_back = file.read()
  File "encodings.ascii", line 26, in decode
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 207: ordinal not in range(128)
```